### PR TITLE
Log websocket close code before reconnecting

### DIFF
--- a/new_pairs.py
+++ b/new_pairs.py
@@ -332,9 +332,12 @@ async def main():
         while True:
             try:
                 await listen()
+            except websockets.ConnectionClosed as e:
+                print(f"[ws] closed: close_code={e.code} close_reason={e.reason}")
             except Exception as e:
-                print(f"[ws] error: {e}, reconnecting in 5s...")
-                await asyncio.sleep(5)
+                print(f"[ws] error: {e}")
+            print("[ws] reconnecting in 5s...")
+            await asyncio.sleep(5)
     finally:
         for t in (maintenance_task, prices_task):
             t.cancel()


### PR DESCRIPTION
## Summary
- Catch `ConnectionClosed` in main retry loop
- Log websocket close code and reason before printing reconnect message

## Testing
- `pytest -q` *(fails: fixture 'address' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b55dd89ae08327a926f686acd8cc5f